### PR TITLE
Additional AFOAuth1Token initializer

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -159,5 +159,6 @@ extern NSString * const kAFApplicationLaunchOptionsURLKey;
  
  */
 - (id)initWithQueryString:(NSString *)queryString;
+- (id)initWithAttributes:(NSDictionary*)attributes;
 
 @end

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -153,25 +153,28 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 @dynamic expired;
 
 - (id)initWithQueryString:(NSString *)queryString {
+    NSDictionary *attributes = AFParametersFromQueryString(queryString);
+    return [self initWithAttributes:attributes];
+}
+
+- (id)initWithAttributes:(NSDictionary *)attributes {
     self = [super init];
     if (!self) {
         return nil;
     }
-
-    NSDictionary *attributes = AFParametersFromQueryString(queryString);
-
+    
     self.key = [attributes objectForKey:@"oauth_token"];
     self.secret = [attributes objectForKey:@"oauth_token_secret"];
     self.session = [attributes objectForKey:@"oauth_session_handle"];
-
+    
     if (attributes[@"oauth_token_duration"]) {
         self.expiration = [NSDate dateWithTimeIntervalSinceNow:[[attributes objectForKey:@"oauth_token_duration"] doubleValue]];
     }
-
+    
     if (attributes[@"oauth_token_renewable"]) {
         self.renewable = AFQueryStringValueIsTrue([attributes objectForKey:@"oauth_token_renewable"]);
     }
-
+    
     return self;
 }
 


### PR DESCRIPTION
Hi Mattt,

Some servies (like Tumblr) offer you a permanent oauth token. So the application is supposed to retain this token for every future session. However this library only allows you to initialize the token with the query string. 
I've added a new initializer that accepts a dictionary. This allows you to persist your token data however you want and initialize it on the application launch. 

I hope you like and merge it. 
Thanks for your great work,
Laurin
