### PR TITLE
Always add OAuth parameters

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -329,8 +329,8 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 {
     NSMutableDictionary *mutableParameters = parameters ? [parameters mutableCopy] : [NSMutableDictionary dictionary];
 
+    [mutableParameters addEntriesFromDictionary:[self OAuthParameters]];
     if (self.accessToken) {
-        [mutableParameters addEntriesFromDictionary:[self OAuthParameters]];
         [mutableParameters setValue:self.accessToken.key forKey:@"oauth_token"];
     }
 

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -36,10 +36,10 @@ NSString * const kAFApplicationLaunchOptionsURLKey = @"NSApplicationLaunchOption
 static NSString * AFEncodeBase64WithData(NSData *data) {
     NSUInteger length = [data length];
     NSMutableData *mutableData = [NSMutableData dataWithLength:((length + 2) / 3) * 4];
-
+    
     uint8_t *input = (uint8_t *)[data bytes];
     uint8_t *output = (uint8_t *)[mutableData mutableBytes];
-
+    
     for (NSUInteger i = 0; i < length; i += 3) {
         NSUInteger value = 0;
         for (NSUInteger j = i; j < (i + 3); j++) {
@@ -48,23 +48,23 @@ static NSString * AFEncodeBase64WithData(NSData *data) {
                 value |= (0xFF & input[j]);
             }
         }
-
+        
         static uint8_t const kAFBase64EncodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
+        
         NSUInteger idx = (i / 3) * 4;
         output[idx + 0] = kAFBase64EncodingTable[(value >> 18) & 0x3F];
         output[idx + 1] = kAFBase64EncodingTable[(value >> 12) & 0x3F];
         output[idx + 2] = (i + 1) < length ? kAFBase64EncodingTable[(value >> 6)  & 0x3F] : '=';
         output[idx + 3] = (i + 2) < length ? kAFBase64EncodingTable[(value >> 0)  & 0x3F] : '=';
     }
-
+    
     return [[NSString alloc] initWithData:mutableData encoding:NSASCIIStringEncoding];
 }
 
 static NSString * AFPercentEscapedQueryStringPairMemberFromStringWithEncoding(NSString *string, NSStringEncoding encoding) {
     static NSString * const kAFCharactersToBeEscaped = @":/?&=;+!@#$()~";
     static NSString * const kAFCharactersToLeaveUnescaped = @"[].";
-
+    
 	return (__bridge_transfer  NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)string, (__bridge CFStringRef)kAFCharactersToLeaveUnescaped, (__bridge CFStringRef)kAFCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));
 }
 
@@ -74,22 +74,22 @@ static NSDictionary * AFParametersFromQueryString(NSString *queryString) {
         NSScanner *parameterScanner = [[NSScanner alloc] initWithString:queryString];
         NSString *name = nil;
         NSString *value = nil;
-
+        
         while (![parameterScanner isAtEnd]) {
             name = nil;
             [parameterScanner scanUpToString:@"=" intoString:&name];
             [parameterScanner scanString:@"=" intoString:NULL];
-
+            
             value = nil;
             [parameterScanner scanUpToString:@"&" intoString:&value];
             [parameterScanner scanString:@"&" intoString:NULL];
-
+            
             if (name && value) {
-                [parameters setValue:[value stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding] forKey:[name stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+                [parameters setObject:[value stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding] forKey:[name stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
             }
         }
     }
-
+    
     return parameters;
 }
 
@@ -101,7 +101,7 @@ static inline NSString * AFNounce() {
     CFUUIDRef uuid = CFUUIDCreate(NULL);
     CFStringRef string = CFUUIDCreateString(NULL, uuid);
     CFRelease(uuid);
-
+    
     return (NSString *)CFBridgingRelease(string);
 }
 
@@ -118,17 +118,17 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     NSString *secret = tokenSecret ? tokenSecret : @"";
     NSString *secretString = [NSString stringWithFormat:@"%@&%@", consumerSecret, secret];
     NSData *secretStringData = [secretString dataUsingEncoding:stringEncoding];
-
+    
     NSString *queryString = AFPercentEscapedQueryStringPairMemberFromStringWithEncoding([[[[[request URL] query] componentsSeparatedByString:@"&"] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)] componentsJoinedByString:@"&"], stringEncoding);
     NSString *requestString = [NSString stringWithFormat:@"%@&%@&%@", [request HTTPMethod], AFPercentEscapedQueryStringPairMemberFromStringWithEncoding([[[request URL] absoluteString] componentsSeparatedByString:@"?"][0], stringEncoding), queryString];
     NSData *requestStringData = [requestString dataUsingEncoding:stringEncoding];
-
+    
     uint8_t digest[CC_SHA1_DIGEST_LENGTH];
     CCHmacContext cx;
     CCHmacInit(&cx, kCCHmacAlgSHA1, [secretStringData bytes], [secretStringData length]);
     CCHmacUpdate(&cx, [requestStringData bytes], [requestStringData length]);
     CCHmacFinal(&cx, digest);
-
+    
     return AFEncodeBase64WithData([NSData dataWithBytes:digest length:CC_SHA1_DIGEST_LENGTH]);
 }
 
@@ -159,34 +159,34 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 {
     NSParameterAssert(clientID);
     NSParameterAssert(secret);
-
+    
     self = [super initWithBaseURL:url];
     if (!self) {
         return nil;
     }
-
+    
     self.key = clientID;
     self.secret = secret;
-
+    
     self.signatureMethod = AFHMACSHA1SignatureMethod;
-
+    
     self.oauthAccessMethod = @"GET";
-
+    
     return self;
 }
 
 - (NSDictionary *)OAuthParameters {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-    [parameters setValue:kAFOAuth1Version forKey:@"oauth_version"];
-    [parameters setValue:NSStringFromAFOAuthSignatureMethod(self.signatureMethod) forKey:@"oauth_signature_method"];
-    [parameters setValue:self.key forKey:@"oauth_consumer_key"];
-    [parameters setValue:[[NSNumber numberWithInteger:floorf([[NSDate date] timeIntervalSince1970])] stringValue] forKey:@"oauth_timestamp"];
-    [parameters setValue:AFNounce() forKey:@"oauth_nonce"];
-
+    [parameters setObject:kAFOAuth1Version forKey:@"oauth_version"];
+    [parameters setObject:NSStringFromAFOAuthSignatureMethod(self.signatureMethod) forKey:@"oauth_signature_method"];
+    [parameters setObject:self.key forKey:@"oauth_consumer_key"];
+    [parameters setObject:[[NSNumber numberWithInteger:floorf([[NSDate date] timeIntervalSince1970])] stringValue] forKey:@"oauth_timestamp"];
+    [parameters setObject:AFNounce() forKey:@"oauth_nonce"];
+    
     if (self.realm) {
-        [parameters setValue:self.realm forKey:@"realm"];
+        [parameters setObject:self.realm forKey:@"realm"];
     }
-
+    
     return parameters;
 }
 
@@ -197,9 +197,9 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 {
     NSMutableURLRequest *request = [super requestWithMethod:@"GET" path:path parameters:parameters];
     [request setHTTPMethod:method];
-
+    
     NSString *tokenSecret = token ? token.secret : nil;
-
+    
     switch (self.signatureMethod) {
         case AFHMACSHA1SignatureMethod:
             return AFHMACSHA1Signature(request, self.secret, tokenSecret, self.stringEncoding);
@@ -210,18 +210,18 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 
 - (NSString *)authorizationHeaderForParameters:(NSDictionary *)parameters {
     static NSString * const kAFOAuth1AuthorizationFormatString = @"OAuth %@";
-
+    
     if (!parameters) {
         return nil;
     }
-
+    
     NSArray *sortedComponents = [[AFQueryStringFromParametersWithEncoding(parameters, self.stringEncoding) componentsSeparatedByString:@"&"] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
     NSMutableArray *mutableComponents = [NSMutableArray array];
     for (NSString *component in sortedComponents) {
         NSArray *subcomponents = [component componentsSeparatedByString:@"="];
         [mutableComponents addObject:[NSString stringWithFormat:@"%@=\"%@\"", [subcomponents objectAtIndex:0], [subcomponents objectAtIndex:1]]];
     }
-
+    
     return [NSString stringWithFormat:kAFOAuth1AuthorizationFormatString, [mutableComponents componentsJoinedByString:@", "]];
 }
 
@@ -239,12 +239,12 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
         __block AFOAuth1Token *currentRequestToken = requestToken;
         [[NSNotificationCenter defaultCenter] addObserverForName:kAFApplicationLaunchedWithURLNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notification) {
             NSURL *url = [[notification userInfo] valueForKey:kAFApplicationLaunchOptionsURLKey];
-
+            
             currentRequestToken.verifier = [AFParametersFromQueryString([url query]) valueForKey:@"oauth_verifier"];
-
+            
             [self acquireOAuthAccessTokenWithPath:accessTokenPath requestToken:currentRequestToken accessMethod:accessMethod success:^(AFOAuth1Token * accessToken) {
                 self.accessToken = accessToken;
-
+                
                 if (success) {
                     success(accessToken);
                 }
@@ -254,9 +254,9 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                 }
             }];
         }];
-
+        
         NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-        [parameters setValue:requestToken.key forKey:@"oauth_token"];
+        [parameters setObject:requestToken.key forKey:@"oauth_token"];
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
         [[UIApplication sharedApplication] openURL:[[self requestWithMethod:@"GET" path:userAuthorizationPath parameters:parameters] URL]];
 #else
@@ -276,11 +276,11 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                  failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *parameters = [[self OAuthParameters] mutableCopy];
-    [parameters setValue:[callbackURL absoluteString] forKey:@"oauth_callback"];
-
+    [parameters setObject:[callbackURL absoluteString] forKey:@"oauth_callback"];
+    
     NSMutableURLRequest *request = [self requestWithMethod:accessMethod path:path parameters:parameters];
     [request setHTTPBody:nil];
-
+    
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (success) {
             AFOAuth1Token *accessToken = [[AFOAuth1Token alloc] initWithQueryString:operation.responseString];
@@ -291,7 +291,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
             failure(error);
         }
     }];
-
+    
     [self enqueueHTTPRequestOperation:operation];
 }
 
@@ -302,11 +302,11 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                 failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *parameters = [[self OAuthParameters] mutableCopy];
-    [parameters setValue:requestToken.key forKey:@"oauth_token"];
-    [parameters setValue:requestToken.verifier forKey:@"oauth_verifier"];
-
+    [parameters setObject:requestToken.key forKey:@"oauth_token"];
+    [parameters setObject:requestToken.verifier forKey:@"oauth_verifier"];
+    
     NSMutableURLRequest *request = [self requestWithMethod:accessMethod path:path parameters:parameters];
-
+    
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (success) {
             AFOAuth1Token *accessToken = [[AFOAuth1Token alloc] initWithQueryString:operation.responseString];
@@ -317,7 +317,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
             failure(error);
         }
     }];
-
+    
     [self enqueueHTTPRequestOperation:operation];
 }
 
@@ -328,18 +328,18 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                 parameters:(NSDictionary *)parameters
 {
     NSMutableDictionary *mutableParameters = parameters ? [parameters mutableCopy] : [NSMutableDictionary dictionary];
-
+    
     [mutableParameters addEntriesFromDictionary:[self OAuthParameters]];
     if (self.accessToken) {
-        [mutableParameters setValue:self.accessToken.key forKey:@"oauth_token"];
+        [mutableParameters setObject:self.accessToken.key forKey:@"oauth_token"];
     }
-
-    [mutableParameters setValue:[self OAuthSignatureForMethod:method path:path parameters:mutableParameters token:self.accessToken] forKey:@"oauth_signature"];
-
+    
+    [mutableParameters setObject:[self OAuthSignatureForMethod:method path:path parameters:mutableParameters token:self.accessToken] forKey:@"oauth_signature"];
+    
     NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:parameters];
     [request setValue:[self authorizationHeaderForParameters:mutableParameters] forHTTPHeaderField:@"Authorization"];
     [request setHTTPShouldHandleCookies:NO];
-
+    
     return request;
 }
 
@@ -368,19 +368,19 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     if (!queryString || [queryString length] == 0) {
         return nil;
     }
-
+    
     NSDictionary *attributes = AFParametersFromQueryString(queryString);
-
+    
     NSDate *expiration = nil;
     if (attributes[@"oauth_token_duration"]) {
         expiration = [NSDate dateWithTimeIntervalSinceNow:[[attributes objectForKey:@"oauth_token_duration"] doubleValue]];
     }
-
+    
     BOOL canBeRenewed = NO;
     if (attributes[@"oauth_token_renewable"]) {
         canBeRenewed = AFQueryStringValueIsTrue([attributes objectForKey:@"oauth_token_renewable"]);
     }
-
+    
     return [self initWithKey:[attributes objectForKey:@"oauth_token"] secret:[attributes objectForKey:@"oauth_token_secret"] session:[attributes objectForKey:@"oauth_session_handle"] expiration:expiration renewable:canBeRenewed];
 }
 
@@ -392,12 +392,12 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 {
     NSParameterAssert(key);
     NSParameterAssert(secret);
-
+    
     self = [super init];
     if (!self) {
         return nil;
     }
-
+    
     self.key = key;
     self.secret = secret;
     self.session = session;


### PR DESCRIPTION
Tumblr gives you a OAuth key on request. The get the access token, you need to send a fully signed request without the access token. However, this is currently not possible since AFOAuth1Client only adds its OAuth parameters when it has an accessToken assigned.

Also, I've swapped all -setValue:forKey: with -setObject:forKey: because this is faster and the actual idea of this method compared to -setValue:forKey:.

Hope you like it
