### PR TITLE
Fixes for Flickr OAuth implementation.

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -305,7 +305,9 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     [parameters setValue:requestToken.key forKey:@"oauth_token"];
     [parameters setValue:requestToken.verifier forKey:@"oauth_verifier"];
 
+    self.accessToken = requestToken;
     NSMutableURLRequest *request = [self requestWithMethod:accessMethod path:path parameters:parameters];
+    self.accessToken = nil;
 
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (success) {

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -338,7 +338,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 
     [mutableParameters setValue:[self OAuthSignatureForMethod:method path:path parameters:mutableParameters token:self.accessToken] forKey:@"oauth_signature"];
 
-    NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:parameters];
+    NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:mutableParameters];
     [request setValue:[self authorizationHeaderForParameters:mutableParameters] forHTTPHeaderField:@"Authorization"];
     [request setHTTPShouldHandleCookies:NO];
 


### PR DESCRIPTION
:)
### In Flickr OAuth implementation, 'oauth_token_secret' key is returned after 'oauth/request_token' request. The key is needed for signing 'oauth/access_token' request later and this commit attempts to fix it.

The current AFOAuth1Client implementation only assign `accessToken` after 'oauth/access_token' request. This may work for Twitter, but this will not work for Flickr.
The signing method looks for `accessToken` when attempting to build the secret key needed, so we had to wrap the following logic by temporary assigning `accessToken` with `requestToken` to trick the signing method to sign with the correct key.
After making this change, I ran the sample code and it seems to work well for twitter as well.
### Flickr OAuth implementation are done through GET parameters instead of request header. Another fixed for Flickr OAuth implementation.

The URL are not built with the modified parameters (although its Authorization header is built with modified parameters).
This will not work for Flickr because its implementation depends on the query of the URL instead of the Authorization header.

Reference: http://www.flickr.com/services/api/auth.oauth.html
