### PR TITLE
Adding comma (,) as a percent escaped character

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -62,7 +62,7 @@ static NSString * AFEncodeBase64WithData(NSData *data) {
 }
 
 static NSString * AFPercentEscapedQueryStringPairMemberFromStringWithEncoding(NSString *string, NSStringEncoding encoding) {
-    static NSString * const kAFCharactersToBeEscaped = @":/?&=;+!@#$()~";
+    static NSString * const kAFCharactersToBeEscaped = @":/?&=;+!@#$()~',";
     static NSString * const kAFCharactersToLeaveUnescaped = @"[].";
 
 	return (__bridge_transfer  NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)string, (__bridge CFStringRef)kAFCharactersToLeaveUnescaped, (__bridge CFStringRef)kAFCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));


### PR DESCRIPTION
 since it's in the reserved words per the RFC. This lines up with:

https://github.com/AFNetworking/AFNetworking/pull/814

since signing the escaped parameters and the actual escaping have to line up
