### PR TITLE
Added multipartFormRequest and refactored auth header

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -143,7 +143,9 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                  path:(NSString *)path
                            parameters:(NSDictionary *)parameters
                                 token:(AFOAuth1Token *)requestToken;
-- (NSString *)authorizationHeaderForParameters:(NSDictionary *)parameters;
+- (NSString *)authorizationHeaderForMethod:(NSString*)method
+                                      path:(NSString*)path
+                                parameters:(NSDictionary *)parameters;
 @end
 
 @implementation AFOAuth1Client
@@ -208,14 +210,21 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     }
 }
 
-- (NSString *)authorizationHeaderForParameters:(NSDictionary *)parameters {
+- (NSString *)authorizationHeaderForMethod:(NSString*)method
+                                      path:(NSString*)path
+                                parameters:(NSDictionary *)parameters {
     static NSString * const kAFOAuth1AuthorizationFormatString = @"OAuth %@";
 
-    if (!parameters) {
-        return nil;
+    NSMutableDictionary *mutableParameters = parameters ? [parameters mutableCopy] : [NSMutableDictionary dictionary];
+    
+    if (self.accessToken) {
+        [mutableParameters addEntriesFromDictionary:[self OAuthParameters]];
+        [mutableParameters setValue:self.accessToken.key forKey:@"oauth_token"];
     }
+    
+    [mutableParameters setValue:[self OAuthSignatureForMethod:method path:path parameters:mutableParameters token:self.accessToken] forKey:@"oauth_signature"];
 
-    NSArray *sortedComponents = [[AFQueryStringFromParametersWithEncoding(parameters, self.stringEncoding) componentsSeparatedByString:@"&"] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
+    NSArray *sortedComponents = [[AFQueryStringFromParametersWithEncoding(mutableParameters, self.stringEncoding) componentsSeparatedByString:@"&"] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
     NSMutableArray *mutableComponents = [NSMutableArray array];
     for (NSString *component in sortedComponents) {
         NSArray *subcomponents = [component componentsSeparatedByString:@"="];
@@ -327,19 +336,22 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                       path:(NSString *)path
                                 parameters:(NSDictionary *)parameters
 {
-    NSMutableDictionary *mutableParameters = parameters ? [parameters mutableCopy] : [NSMutableDictionary dictionary];
-
-    if (self.accessToken) {
-        [mutableParameters addEntriesFromDictionary:[self OAuthParameters]];
-        [mutableParameters setValue:self.accessToken.key forKey:@"oauth_token"];
-    }
-
-    [mutableParameters setValue:[self OAuthSignatureForMethod:method path:path parameters:mutableParameters token:self.accessToken] forKey:@"oauth_signature"];
-
     NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:parameters];
-    [request setValue:[self authorizationHeaderForParameters:mutableParameters] forHTTPHeaderField:@"Authorization"];
+    [request setValue:[self authorizationHeaderForMethod:method path:path parameters:parameters] forHTTPHeaderField:@"Authorization"];
     [request setHTTPShouldHandleCookies:NO];
 
+    return request;
+}
+
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                                   path:(NSString *)path
+                                             parameters:(NSDictionary *)parameters
+                              constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
+{
+    NSMutableURLRequest* request = [super multipartFormRequestWithMethod:method path:path parameters:parameters constructingBodyWithBlock:block];
+    [request setValue:[self authorizationHeaderForMethod:method path:path parameters:parameters] forHTTPHeaderField:@"Authorization"];
+    [request setHTTPShouldHandleCookies:NO];
+    
     return request;
 }
 


### PR DESCRIPTION
As you mentioned in my issue on AFNetworking (https://github.com/AFNetworking/AFNetworking/issues/815#issuecomment-13863968) the proper way to get a signed multipartFormRequest would be to override it, so I took a crack at doing so in AFOAuth1Client.

For tidy-ness I refactored the authorizationHeader stuff, since that function is only ever called from requestWithMethod, and I needed to do the same in multipartFormRequestWithMethod.

I tested by posting a photo to Tumblr and it seemed to work fine.

Let me know what you think!
