### PR TITLE
Unregister from application launch notifications

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -137,6 +137,9 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 @interface AFOAuth1Client ()
 @property (readwrite, nonatomic, copy) NSString *key;
 @property (readwrite, nonatomic, copy) NSString *secret;
+@property (readwrite, nonatomic, strong) id applicationLaunchNotificationObserver;
+
+-(void)unregisterFromApplicationLaunchNotifications;
 
 - (NSDictionary *)OAuthParameters;
 - (NSString *)OAuthSignatureForMethod:(NSString *)method
@@ -175,6 +178,18 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     self.oauthAccessMethod = @"GET";
 
     return self;
+}
+
+- (void)dealloc
+{
+  [self unregisterFromApplicationLaunchNotifications];
+}
+
+-(void)unregisterFromApplicationLaunchNotifications {
+  if (self.applicationLaunchNotificationObserver) {
+    [[NSNotificationCenter defaultCenter] removeObserver:self.applicationLaunchNotificationObserver];
+    self.applicationLaunchNotificationObserver = nil;
+  }
 }
 
 - (NSDictionary *)OAuthParameters {
@@ -257,31 +272,39 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 {
     [self acquireOAuthRequestTokenWithPath:requestTokenPath callback:callbackURL accessMethod:(NSString *)accessMethod success:^(AFOAuth1Token *requestToken) {
         __block AFOAuth1Token *currentRequestToken = requestToken;
-      
-      __block id applicationLaunchNotificationObserver = [[NSNotificationCenter defaultCenter]
-                                                          addObserverForName:kAFApplicationLaunchedWithURLNotification
-                                                          object:nil
-                                                          queue:[NSOperationQueue mainQueue]
-                                                          usingBlock:^(NSNotification *notification) {
-                                                            
-                                                            [[NSNotificationCenter defaultCenter] removeObserver:applicationLaunchNotificationObserver];
-                                                            NSURL *url = [[notification userInfo] valueForKey:kAFApplicationLaunchOptionsURLKey];
-                                                            
-                                                            currentRequestToken.verifier = [AFParametersFromQueryString([url query]) valueForKey:@"oauth_verifier"];
-                                                            
-                                                            [self acquireOAuthAccessTokenWithPath:accessTokenPath requestToken:currentRequestToken accessMethod:accessMethod success:^(AFOAuth1Token * accessToken) {
+        
+        // Make sure not to register multiple notification observers.
+        // Handles the case where sign-in was cancelled by the user while in the external browser.
+        if (self.applicationLaunchNotificationObserver) {
+            [self unregisterFromApplicationLaunchNotifications];
+        }
+        
+        self.applicationLaunchNotificationObserver = [[NSNotificationCenter defaultCenter]
+                                                      addObserverForName:kAFApplicationLaunchedWithURLNotification
+                                                      object:nil
+                                                      queue:[NSOperationQueue mainQueue]
+                                                      usingBlock:^(NSNotification *notification) {
+                                                          
+                                                          // Unregister from further notifications.
+                                                          [self unregisterFromApplicationLaunchNotifications];
+                                                          
+                                                          NSURL *url = [[notification userInfo] valueForKey:kAFApplicationLaunchOptionsURLKey];
+                                                          
+                                                          currentRequestToken.verifier = [AFParametersFromQueryString([url query]) valueForKey:@"oauth_verifier"];
+                                                          
+                                                          [self acquireOAuthAccessTokenWithPath:accessTokenPath requestToken:currentRequestToken accessMethod:accessMethod success:^(AFOAuth1Token * accessToken) {
                                                               self.accessToken = accessToken;
                                                               
                                                               if (success) {
-                                                                success(accessToken);
+                                                                  success(accessToken);
                                                               }
-                                                            } failure:^(NSError *error) {
+                                                          } failure:^(NSError *error) {
                                                               if (failure) {
-                                                                failure(error);
+                                                                  failure(error);
                                                               }
-                                                            }];
                                                           }];
-
+                                                      }];
+        
         NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
         [parameters setValue:requestToken.key forKey:@"oauth_token"];
 #if __IPHONE_OS_VERSION_MIN_REQUIRED

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -285,9 +285,6 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                                       queue:[NSOperationQueue mainQueue]
                                                       usingBlock:^(NSNotification *notification) {
                                                           
-                                                          // Unregister from further notifications.
-                                                          [self unregisterFromApplicationLaunchNotifications];
-                                                          
                                                           NSURL *url = [[notification userInfo] valueForKey:kAFApplicationLaunchOptionsURLKey];
                                                           
                                                           currentRequestToken.verifier = [AFParametersFromQueryString([url query]) valueForKey:@"oauth_verifier"];
@@ -303,6 +300,10 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                                                   failure(error);
                                                               }
                                                           }];
+                                                        
+                                                          // Unregister from further notifications.
+                                                          [self unregisterFromApplicationLaunchNotifications];
+                                                        
                                                       }];
         
         NSMutableDictionary *parameters = [NSMutableDictionary dictionary];

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -139,7 +139,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 @property (readwrite, nonatomic, copy) NSString *secret;
 @property (readwrite, nonatomic, strong) id applicationLaunchNotificationObserver;
 
--(void)unregisterFromApplicationLaunchNotifications;
+-(void)removeApplicationLaunchNotificationObserver;
 
 - (NSDictionary *)OAuthParameters;
 - (NSString *)OAuthSignatureForMethod:(NSString *)method
@@ -182,10 +182,11 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 
 - (void)dealloc
 {
-  [self unregisterFromApplicationLaunchNotifications];
+  [self removeApplicationLaunchNotificationObserver];
 }
 
--(void)unregisterFromApplicationLaunchNotifications {
+-(void)removeApplicationLaunchNotificationObserver
+{
   if (self.applicationLaunchNotificationObserver) {
     [[NSNotificationCenter defaultCenter] removeObserver:self.applicationLaunchNotificationObserver];
     self.applicationLaunchNotificationObserver = nil;
@@ -276,7 +277,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
         // Make sure not to register multiple notification observers.
         // Handles the case where sign-in was cancelled by the user while in the external browser.
         if (self.applicationLaunchNotificationObserver) {
-            [self unregisterFromApplicationLaunchNotifications];
+            [self removeApplicationLaunchNotificationObserver];
         }
         
         self.applicationLaunchNotificationObserver = [[NSNotificationCenter defaultCenter]
@@ -302,7 +303,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                                           }];
                                                         
                                                           // Unregister from further notifications.
-                                                          [self unregisterFromApplicationLaunchNotifications];
+                                                          [self removeApplicationLaunchNotificationObserver];
                                                         
                                                       }];
         


### PR DESCRIPTION
I ran into problems when using the AFOAuth1Client in a process where there is log-out functionality in the application and the authentication process needs to be restarted.
The client never unregisters from the kAFApplicationLaunchedWithURLNotification notification, getting the result of multiple observation blocks getting executed.

Added functionality
- unregisters from the notification inside the notification block.
- handle the case where the user cancels an auth flow and returns to the app:
  -- unregister any previous registered notification block before registering a new one
  -- unregister in dealloc to fullfil the contract to addObserverForName:object:queue:usingBlock.
