### PR TITLE
Add flag to disable signing multipart data with OAuth

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -57,6 +57,13 @@ typedef enum {
  */
 @property (nonatomic, strong) NSString *oauthAccessMethod;
 
+/** Disable including multipart data in OAuth signature.
+
+ Some servers expect what multipart data will be not included in OAuth
+ signature and signing it will cause authentication error.
+ */
+@property (nonatomic, assign, getter = isDisabledMultipartDataInOauth) BOOL disableMultipartDataInOauth;
+
 ///---------------------
 /// @name Initialization
 ///---------------------

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -362,9 +362,12 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                               constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
 {
     NSMutableURLRequest *request = [super multipartFormRequestWithMethod:method path:path parameters:parameters constructingBodyWithBlock:block];
-    [request setValue:[self authorizationHeaderForMethod:method path:path parameters:parameters] forHTTPHeaderField:@"Authorization"];
-    [request setHTTPShouldHandleCookies:NO];
-    
+
+    if (!self.isDisabledMultipartDataInOauth) {
+        [request setValue:[self authorizationHeaderForMethod:method path:path parameters:parameters] forHTTPHeaderField:@"Authorization"];
+        [request setHTTPShouldHandleCookies:NO];
+    }
+
     return request;
 }
 


### PR DESCRIPTION
Some servers expect what multipart data will be not included in OAuth
 signature and signing it will cause authentication error.
