### PR TITLE
Updates request factory to exclude oauth_* params due to Authorization header

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -351,7 +351,15 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                       path:(NSString *)path
                                 parameters:(NSDictionary *)parameters
 {
-    NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:nil];
+    NSMutableDictionary *requestParameters = [parameters mutableCopy];
+    for (NSString* parameterName in parameters) {
+        if ([parameterName hasPrefix:@"oauth_"]) {
+            [requestParameters removeObjectForKey:parameterName];
+        }
+    }
+    
+    NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:requestParameters];
+    
     [request setValue:[self authorizationHeaderForMethod:method path:path parameters:parameters] forHTTPHeaderField:@"Authorization"];
     [request setHTTPShouldHandleCookies:NO];
     

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -277,10 +277,12 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 
         NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
         [parameters setValue:requestToken.key forKey:@"oauth_token"];
+        NSMutableURLRequest *request = [super requestWithMethod:@"GET" path:userAuthorizationPath parameters:parameters];
+        [request setHTTPShouldHandleCookies:NO];
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
-        [[UIApplication sharedApplication] openURL:[[self requestWithMethod:@"GET" path:userAuthorizationPath parameters:parameters] URL]];
+        [[UIApplication sharedApplication] openURL:[request URL]];
 #else
-        [[NSWorkspace sharedWorkspace] openURL:[[self requestWithMethod:@"GET" path:userAuthorizationPath parameters:parameters] URL]];
+        [[NSWorkspace sharedWorkspace] openURL:[request URL]];
 #endif
     } failure:^(NSError *error) {
         if (failure) {
@@ -349,7 +351,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                       path:(NSString *)path
                                 parameters:(NSDictionary *)parameters
 {
-    NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:parameters];
+    NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:nil];
     [request setValue:[self authorizationHeaderForMethod:method path:path parameters:parameters] forHTTPHeaderField:@"Authorization"];
     [request setHTTPShouldHandleCookies:NO];
     


### PR DESCRIPTION
Requests should not use url or post params if Authorization header is used, see 

http://oauth.net/core/1.0/ (5.2. Consumer Request Parameters) states that it should be one of Authorization header, POST params, or URL  params (preference in that order).

Twitter API also has issues with this, https://dev.twitter.com/docs/api/1/post/oauth/request_token, states "If you're using HTTP-header based OAuth, you shouldn't include oauth_\* parameters in the POST body or querystring"

Personally, I noticed this when using an API that uses django-piston, which creates a multi value dict for params so when there are duplicates I see invalid signatures.

This update removes the passing of the parameters argument to the request creation in requestWithMethod:path:parameters. The request created for the authorization step also had to be updated to use the url parameters because it was using this method before.
