### PR TITLE
Exclude oauth_* parameters from POST request body

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -349,7 +349,26 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                       path:(NSString *)path
                                 parameters:(NSDictionary *)parameters
 {
-    NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:parameters];
+    NSMutableDictionary *requestParameters = [parameters mutableCopy];
+    
+    
+    if ([method isEqual:@"POST"]) {
+        
+        // ensure that our POST body parameters do not include anything prefixed with oauth_
+        // as these are included in the Authorization header (as per http://tools.ietf.org/html/rfc5849#section-3.5)
+        for (NSString* parameterName in parameters) {
+            
+            if ([parameterName hasPrefix:@"oauth_"]) {
+                [requestParameters removeObjectForKey:parameterName];
+            }
+        }
+        
+        
+    }
+    
+    NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:requestParameters];
+    
+    // note that here we use the FULL parameter string (including oauth_*) for the purposes of signature generation
     [request setValue:[self authorizationHeaderForMethod:method path:path parameters:parameters] forHTTPHeaderField:@"Authorization"];
     [request setHTTPShouldHandleCookies:NO];
     


### PR DESCRIPTION
...ests.

The OAuth Specification says that requests should include the protocol parameters in EITHER the Authorization: HTTP header OR the request body, and to prefer the Header method. We're already using the header, so we can skip including them in the request body.

The relevant section of the specification is: http://tools.ietf.org/html/rfc5849#section-3.5.

(Hopefully my Objective-C is OK! Corrections welcomed! :smile:)

Note that this fixes interaction with some of the more strict APIs, such as that provided by [Xero](http://xero.com)
