### PR TITLE
Don't Escape Tildes as per Instructions in RFC 3986 and OAuth 1.0 Spec

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -62,7 +62,7 @@ static NSString * AFEncodeBase64WithData(NSData *data) {
 }
 
 static NSString * AFPercentEscapedQueryStringPairMemberFromStringWithEncoding(NSString *string, NSStringEncoding encoding) {
-    static NSString * const kAFCharactersToBeEscaped = @":/?&=;+!@#$()~',";
+    static NSString * const kAFCharactersToBeEscaped = @":/?&=;+!@#$()',";
     static NSString * const kAFCharactersToLeaveUnescaped = @"[].";
 
 	return (__bridge_transfer  NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)string, (__bridge CFStringRef)kAFCharactersToLeaveUnescaped, (__bridge CFStringRef)kAFCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));


### PR DESCRIPTION
If I'm reading these passages correctly, the tilde shouldn't be escaped:

> All parameter names and values are escaped using the [RFC3986] percent-encoding 
> (%xx) mechanism. Characters not in the unreserved character set 
> ([RFC3986] section 2.3) MUST be encoded. **Characters in the unreserved 
> character set MUST NOT be encoded.** Hexadecimal characters in encodings 
> MUST be upper case. Text names and values MUST be encoded as UTF-8 
> octets before percent-encoding them per [RFC3629].
> unreserved = ALPHA, DIGIT, '-', '.', '_', '~'

from http://oauth.net/core/1.0/#encoding_parameters

and

> For consistency, percent-encoded octets in the ranges of ALPHA
> (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E),
> underscore (%5F), or tilde (%7E) **should not be created by URI
> producers** and, when found in a URI, should be decoded to their
> corresponding unreserved characters by URI normalizers.

from http://tools.ietf.org/html/rfc3986#section-2.3
