### PR TITLE
Pass response object of OAuth response

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -81,7 +81,7 @@ typedef enum {
                                     callbackURL:(NSURL *)callbackURL
                                 accessTokenPath:(NSString *)accessTokenPath
                                    accessMethod:(NSString *)accessMethod
-                                        success:(void (^)(AFOAuth1Token *accessToken))success
+                                        success:(void (^)(AFOAuth1Token *accessToken, id responseObject))success
                                         failure:(void (^)(NSError *error))failure;
 
 /**
@@ -90,7 +90,7 @@ typedef enum {
 - (void)acquireOAuthRequestTokenWithPath:(NSString *)path
                                 callback:(NSURL *)url
                             accessMethod:(NSString *)accessMethod
-                                 success:(void (^)(AFOAuth1Token *requestToken))success
+                                 success:(void (^)(AFOAuth1Token *requestToken, id responseObject))success
                                  failure:(void (^)(NSError *error))failure;
 
 /**
@@ -99,7 +99,7 @@ typedef enum {
 - (void)acquireOAuthAccessTokenWithPath:(NSString *)path
                            requestToken:(AFOAuth1Token *)requestToken
                            accessMethod:(NSString *)accessMethod
-                                success:(void (^)(AFOAuth1Token *accessToken))success
+                                success:(void (^)(AFOAuth1Token *accessToken, id responseObject))success
                                 failure:(void (^)(NSError *error))failure;
 
 @end


### PR DESCRIPTION
Required for some OAuth server implementations, e.g. Withings API. Withings API returns the user ID together with the access token and access secret that are required for subsequent calls to the API
