### PR TITLE
Allow to embed oAuth parameters into the URL as params instead of header fields

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -57,6 +57,8 @@ typedef enum {
  */
 @property (nonatomic, strong) NSString *oauthAccessMethod;
 
+@property (nonatomic, assign) BOOL embedInGetParams;
+
 ///---------------------
 /// @name Initialization
 ///---------------------


### PR DESCRIPTION
Allow to embed oAuth parameters into the URL as params instead of header fields
Some oAuth server implementations only support GET params, e.g. Withings API
