### PR TITLE
Added error handling when return query string doesn't contain oauth parameters

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -263,10 +263,18 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
             currentRequestToken.verifier = [AFParametersFromQueryString([url query]) valueForKey:@"oauth_verifier"];
 
             [self acquireOAuthAccessTokenWithPath:accessTokenPath requestToken:currentRequestToken accessMethod:accessMethod success:^(AFOAuth1Token * accessToken) {
-                self.accessToken = accessToken;
-
-                if (success) {
-                    success(accessToken);
+                
+                if ( accessToken ) {
+                    self.accessToken = accessToken;
+                    
+                    if (success) {
+                        success(accessToken);
+                    }
+                }
+                else {
+                    if (failure) {
+                        failure(nil);
+                    }
                 }
             } failure:^(NSError *error) {
                 if (failure) {
@@ -395,6 +403,10 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     }
 
     NSDictionary *attributes = AFParametersFromQueryString(queryString);
+    
+    if ( attributes.count == 0 ) {
+        return nil;
+    }
 
     NSDate *expiration = nil;
     if (attributes[@"oauth_token_duration"]) {


### PR DESCRIPTION
Added error handling when return query string doesn't contain oauth parameters

This lead to a crash/assert before. This situation might occur if you quickly register/unregister with a service. In my case the query string contained "Invalid verifier" and no other parameters.
