### PR TITLE
implement expiry method

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -468,7 +468,6 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 @synthesize verifier = _verifier;
 @synthesize expiration = _expiration;
 @synthesize renewable = _renewable;
-@dynamic expired;
 
 - (id)initWithQueryString:(NSString *)queryString {
     if (!queryString || [queryString length] == 0) {
@@ -515,6 +514,10 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     self.renewable = canBeRenewed;
     
     return self;
+}
+
+- (BOOL)isExpired{
+    return [self.expiration compare:[NSDate date]] == NSOrderedDescending;
 }
 
 #pragma mark - NSCoding


### PR DESCRIPTION
I've noticed that the property `expired` is marked as dynamic and results in an unrecognized selector exception for the getter `isExpired`
