### PR TITLE
Add a method to create an unauthenticated request.

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -103,6 +103,18 @@ typedef enum {
                                 success:(void (^)(AFOAuth1Token *accessToken, id responseObject))success
                                 failure:(void (^)(NSError *error))failure;
 
+///---------------------
+/// @name Requests
+///---------------------
+
+/**
+
+ */
+- (NSMutableURLRequest *)unauthenticatedRequestWithMethod:(NSString *)method
+                                      path:(NSString *)path
+                                parameters:(NSDictionary *)parameters;
+
+
 @end
 
 ///----------------

--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -103,9 +103,9 @@ typedef enum {
                                 success:(void (^)(AFOAuth1Token *accessToken, id responseObject))success
                                 failure:(void (^)(NSError *error))failure;
 
-///---------------------
+///---------------
 /// @name Requests
-///---------------------
+///---------------
 
 /**
 

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -375,6 +375,14 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     [self enqueueHTTPRequestOperation:operation];
 }
 
+- (NSMutableURLRequest *)unauthenticatedRequestWithMethod:(NSString *)method
+                                      path:(NSString *)path
+                                parameters:(NSDictionary *)parameters
+{
+  // Call super (AFHTTPClient) requestWithMethod as we want a URL request without the authentication header and any oauth_ paramaters intact.
+  return [super requestWithMethod:method path:path parameters:parameters];
+}
+
 #pragma mark - AFHTTPClient
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method


### PR DESCRIPTION
Pull request #33 removed all oauth_ parameters when building a url request and correctly creates the initial authorization request with oauth_ parameters intact by calling super to create the URL request:  https://github.com/AFNetworking/AFOAuth1Client/commit/b7e628ab99c04a1ed2d2e5a14228da517d0a94e6#L0R288. 

Unfortunately, if you are using the two separate methods to get a request token and auth token separately there isn't a way to build the authorization request while keeping oauth_ parameters intact using the AFOAuthClient.

I've added a public method, unauthenticatedRequestWithMethod..., to create a URL request that will not include the authentication header and will leave any oauth_ parameters intact. It just calls super to create the URL request with AFHTTPClient. 

This fixes my issue with Flickr where initial authorization requests (created with OAuth client's requestWithMethod) would have the oauth_token param removed and cause Flickr to show error message.
