### PR TITLE
Update Twitter API paths to use API v1.1

### DIFF
--- a/Twitter OSX Example Client/Twitter OSX Example Client/AppDelegate.m
+++ b/Twitter OSX Example Client/Twitter OSX Example Client/AppDelegate.m
@@ -38,7 +38,7 @@
     [self.twitterClient authorizeUsingOAuthWithRequestTokenPath:@"oauth/request_token" userAuthorizationPath:@"oauth/authorize" callbackURL:[NSURL URLWithString:@"af-twitter://success"] accessTokenPath:@"oauth/access_token" accessMethod:@"POST" scope:nil success:^(AFOAuth1Token *accessToken, id responseObject) {
         NSLog(@"Success: %@", accessToken);
         
-        [self.twitterClient getPath:@"1/statuses/user_timeline.json" parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        [self.twitterClient getPath:@"1.1/statuses/user_timeline.json" parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
             NSArray *responseArray = (NSArray *)responseObject;
             [responseArray enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
                 NSLog(@"Success: %@", obj);

--- a/Twitter iOS Example Client/Twitter iOS Example Client/AppDelegate.m
+++ b/Twitter iOS Example Client/Twitter iOS Example Client/AppDelegate.m
@@ -39,7 +39,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 
     [self.twitterClient authorizeUsingOAuthWithRequestTokenPath:@"oauth/request_token" userAuthorizationPath:@"oauth/authorize" callbackURL:[NSURL URLWithString:@"af-twitter://success"] accessTokenPath:@"oauth/access_token" accessMethod:@"POST" scope:nil success:^(AFOAuth1Token *accessToken, id responseObject) {               
         [self.twitterClient registerHTTPOperationClass:[AFJSONRequestOperation class]];
-        [self.twitterClient getPath:@"1/statuses/user_timeline.json" parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        [self.twitterClient getPath:@"1.1/statuses/user_timeline.json" parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
             NSArray *responseArray = (NSArray *)responseObject;
             [responseArray enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
                 NSLog(@"Success: %@", obj);


### PR DESCRIPTION
API v1 is no longer available. Resolves #47.
