### PR TITLE
Fixing CocoaPods 0.21.0 issues.

### DIFF
--- a/AFOAuth1Client.podspec
+++ b/AFOAuth1Client.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "AFOAuth1Client"
   s.version      = "0.2.1"
-  s.summary      = "AFNetworking Extension for OAuth 1.0a Authentication"
+  s.summary      = "AFNetworking Extension for OAuth 1.0a Authentication."
   s.homepage     = "https://github.com/AFNetworking/AFOAuth1Client"
   s.license      = 'MIT'
   s.author       = { 'Mattt Thompson' => 'm@mattt.me' }
@@ -10,15 +10,26 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.ios.deployment_target = '5.0'
-  s.ios.frameworks = 'Security'
+  s.ios.frameworks = 'MobileCoreServices', 'SystemConfiguration', 'Security', 'CoreGraphics'
 
   s.osx.deployment_target = '10.7'
+  s.osx.frameworks = 'CoreServices', 'SystemConfiguration', 'Security'
 
   s.dependency 'AFNetworking', '>= 1.0'
 
   s.prefix_header_contents = <<-EOS
-#ifdef __OBJC__
+#import <Availability.h>
+
+#define _AFNETWORKING_PIN_SSL_CERTIFICATES_
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <MobileCoreServices/MobileCoreServices.h>
   #import <Security/Security.h>
-#endif /* __OBJC__*/
+#else
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <CoreServices/CoreServices.h>
+  #import <Security/Security.h>
+#endif
 EOS
 end


### PR DESCRIPTION
This pull request fixes AFOAuth1Client.podspec related compiler warnings when building under the new CocoaPods 0.21.0 target system.
