### PR TITLE
Escape consumer secret and token secret for implement RFC 5849

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -116,7 +116,7 @@ static inline NSString * NSStringFromAFOAuthSignatureMethod(AFOAuthSignatureMeth
 
 static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *consumerSecret, NSString *tokenSecret, NSStringEncoding stringEncoding) {
     NSString *secret = tokenSecret ? tokenSecret : @"";
-    NSString *secretString = [NSString stringWithFormat:@"%@&%@", consumerSecret, secret];
+    NSString *secretString = [NSString stringWithFormat:@"%@&%@", AFPercentEscapedQueryStringPairMemberFromStringWithEncoding(consumerSecret, stringEncoding), AFPercentEscapedQueryStringPairMemberFromStringWithEncoding(secret, stringEncoding)];
     NSData *secretStringData = [secretString dataUsingEncoding:stringEncoding];
 
     NSString *queryString = AFPercentEscapedQueryStringPairMemberFromStringWithEncoding([[[[[request URL] query] componentsSeparatedByString:@"&"] sortedArrayUsingSelector:@selector(compare:)] componentsJoinedByString:@"&"], stringEncoding);


### PR DESCRIPTION
Consumer secret and token secret must be escaped for implement RFC 5849. AFOAuth1Client dosen't work with [our OAuth service](http://developer.hatena.ne.jp/ja/documents/auth/apis/oauth)  (Sorry, there are no english documents). Because our OAuth's secret token contains some symbols which need to be escaped.
Twitter's OAuth avoids this problem because they use only alphabet and number for secret token. This patch doesn't affect current working code like Twitter client. 

For detail, pelease see RFC 5849 HMAC-SHA1 key section.
http://tools.ietf.org/html/rfc5849#page-25
