### PR TITLE
Fix scope parameter not sent

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -332,7 +332,6 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     }
 
     NSMutableURLRequest *request = [self requestWithMethod:accessMethod path:path parameters:parameters];
-    [request setHTTPBody:nil];
 
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (success) {


### PR DESCRIPTION
Currently scope parameter is ignored because AFOAuth1Client removed HTTP POST body. I don't know why AFOAuth1Client removed body initially. But  this patch works well.
