### PR TITLE
Don't include request parameters in oauth signature if not URL encoded

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -249,8 +249,17 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
         }
     }];
 
-    [mutableParameters addEntriesFromDictionary:mutableAuthorizationParameters];
-    [mutableAuthorizationParameters setValue:[self OAuthSignatureForMethod:method path:path parameters:mutableParameters token:self.accessToken] forKey:@"oauth_signature"];
+	NSDictionary *parametersForSignature;
+	
+	if ([method isEqualToString:@"GET"] || [method isEqualToString:@"HEAD"] || [method isEqualToString:@"DELETE"] || self.parameterEncoding == AFFormURLParameterEncoding) {
+		[mutableParameters addEntriesFromDictionary:mutableAuthorizationParameters];
+		parametersForSignature = mutableParameters;
+	}
+	else {
+		parametersForSignature = mutableAuthorizationParameters;
+	}
+
+    [mutableAuthorizationParameters setValue:[self OAuthSignatureForMethod:method path:path parameters:parametersForSignature token:self.accessToken] forKey:@"oauth_signature"];
     
     NSArray *sortedComponents = [[AFQueryStringFromParametersWithEncoding(mutableAuthorizationParameters, self.stringEncoding) componentsSeparatedByString:@"&"] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
     NSMutableArray *mutableComponents = [NSMutableArray array];


### PR DESCRIPTION
This fixes a deviation from the spec regarding which parameters are included when calculating the OAuth signature.  For requests with parameters in the body, they should only be included if the request's content-type is "application/x-www-form-urlencoded".  See RFC 5849, Section 3.4.1.3.1. (Parameter Sources).
