### PR TITLE
Suppressed optional framework dependency warnings when used as a CocoaPod

### DIFF
--- a/AFOAuth1Client.podspec
+++ b/AFOAuth1Client.podspec
@@ -19,6 +19,14 @@ Pod::Spec.new do |s|
   s.prefix_header_contents = <<-EOS
 #ifdef __OBJC__
   #import <Security/Security.h>
+  
+  #if __IPHONE_OS_VERSION_MIN_REQUIRED
+    #import <SystemConfiguration/SystemConfiguration.h>
+    #import <MobileCoreServices/MobileCoreServices.h>
+  #else
+    #import <SystemConfiguration/SystemConfiguration.h>
+    #import <CoreServices/CoreServices.h>
+  #endif
 #endif /* __OBJC__*/
 EOS
 end


### PR DESCRIPTION
Podspec now imports the SystemConfiguration and CoreServices/MobileCoreServices in pch file.

This will suppress warnings on this CocoaPod's target when it is used as a dependency in other projects.
