### PR TITLE
Add additionalParameters Property, so additional information contained ...

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -137,8 +137,12 @@ extern NSString * const kAFApplicationLaunchOptionsURLKey;
 @property (readonly, nonatomic, copy) NSString *secret;
 
 /**
+ 
+ */
 @property (readonly, nonatomic, strong) NSDictionary *additionalParameters;
 
+/**
+ 
  */
 @property (readonly, nonatomic, copy) NSString *session;
 

--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -137,6 +137,7 @@ extern NSString * const kAFApplicationLaunchOptionsURLKey;
 @property (readonly, nonatomic, copy) NSString *secret;
 
 /**
+@property (readonly, nonatomic, strong) NSDictionary *additionalParameters;
 
  */
 @property (readonly, nonatomic, copy) NSString *session;
@@ -169,6 +170,7 @@ extern NSString * const kAFApplicationLaunchOptionsURLKey;
            secret:(NSString *)secret
           session:(NSString *)session
        expiration:(NSDate *)expiration
-        renewable:(BOOL)canBeRenewed;
+        renewable:(BOOL)canBeRenewed
+additionalParameters:(NSDictionary *)parameters;
 
 @end


### PR DESCRIPTION
...in the query string can be accessed later. (As specified in section 6.3.2 of the oAuth spec: http://oauth.net/core/1.0a/#auth_step3)
