### PR TITLE
Add ability to not sign JSON parameters.

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -57,6 +57,11 @@ typedef enum {
  */
 @property (nonatomic, strong) NSString *oauthAccessMethod;
 
+/**
+
+ */
+@property (nonatomic) BOOL signJSONParameters;
+
 ///---------------------
 /// @name Initialization
 ///---------------------

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -177,6 +177,8 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 
     self.oauthAccessMethod = @"GET";
 
+    self.signJSONParameters = YES;
+
     return self;
 }
 
@@ -232,6 +234,10 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
                                 parameters:(NSDictionary *)parameters
 {
     static NSString * const kAFOAuth1AuthorizationFormatString = @"OAuth %@";
+
+    if (self.parameterEncoding == AFJSONParameterEncoding && !self.signJSONParameters) {
+        parameters = nil;
+    }
 
     NSMutableDictionary *mutableParameters = parameters ? [parameters mutableCopy] : [NSMutableDictionary dictionary];
     NSMutableDictionary *mutableAuthorizationParameters = [NSMutableDictionary dictionary];

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -235,7 +235,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 {
     static NSString * const kAFOAuth1AuthorizationFormatString = @"OAuth %@";
 
-    if (self.parameterEncoding == AFJSONParameterEncoding && !self.signJSONParameters) {
+    if (![method isEqualToString:@"GET"] && self.parameterEncoding == AFJSONParameterEncoding && !self.signJSONParameters) {
         parameters = nil;
     }
 


### PR DESCRIPTION
An API I have to integrate with does not sign the JSON payload as part of the request string. Apparently this is okay according to [the spec](http://oauth.net/core/1.0/#signing_process) because it only specifies:

> Parameters in the HTTP POST request body (with a `content-type` of `application/x-www-form-urlencoded`).

which does not cover a JSON payload.

I've added a `BOOL signJSONParameters` to allow people to perform this non-signing behaviour by setting it to `NO`. It defaults to `YES` to maintain backwards compatibility.
