### PR TITLE
Specify AFNetworking ~>1.3 while AFOAuth1Client fails to build w/ 2.0.0

### DIFF
--- a/AFOAuth1Client.podspec
+++ b/AFOAuth1Client.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   s.osx.deployment_target = '10.7'
 
-  s.dependency 'AFNetworking', '>= 1.0'
+  s.dependency 'AFNetworking', '~> 1.3'
 
   s.prefix_header_contents = <<-EOS
 #ifdef __OBJC__


### PR DESCRIPTION
Stopgap solution to ensure that the Client will continue to build without manually specifying AFNetworking 1.3 in podfile, until it is brought inline with AFN 2.x.x
