### PR TITLE
Rename kAFOAuthCredentialServiceName to kAFOAuth1CredentialServiceName

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -132,12 +132,12 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     return AFEncodeBase64WithData([NSData dataWithBytes:digest length:CC_SHA1_DIGEST_LENGTH]);
 }
 
-NSString * const kAFOAuthCredentialServiceName = @"AFOAuthCredentialService";
+NSString * const kAFOAuth1CredentialServiceName = @"AFOAuthCredentialService";
 
 static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifier) {
     return @{(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
              (__bridge id)kSecAttrAccount: identifier,
-             (__bridge id)kSecAttrService: kAFOAuthCredentialServiceName
+             (__bridge id)kSecAttrService: kAFOAuth1CredentialServiceName
              };
 }
 


### PR DESCRIPTION
Fixes a duplicate symbol error when linking to AFOAuth2Client.

Ref https://github.com/AFNetworking/AFOAuth2Client/blob/master/AFOAuth2Client/AFOAuth2Client.m#L33
