### PR TITLE
Added PUT and PATCH to requestWithMethod to avoid improperly handling JS...

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -399,7 +399,7 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
     // Only use parameters in the HTTP POST request body (with a content-type of `application/x-www-form-urlencoded`).
     // See RFC 5849, Section 3.4.1.3.1 http://tools.ietf.org/html/rfc5849#section-3.4
     NSDictionary *authorizationParameters = parameters;
-    if ([method isEqualToString:@"POST"]) {
+    if ([method isEqualToString:@"POST"] || [method isEqualToString:@"PUT"] || [method isEqualToString:@"PATCH"]) {
         authorizationParameters = ([[request valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"application/x-www-form-urlencoded"] ? parameters : nil);
     }
     


### PR DESCRIPTION
requestWithMethod does the right thing on a POST with JSON data as per the referenced RFC, however PUT and PATCH still have an issue, they should be part of that RFC as well correct? Anyway, minor fix to make that so.
