### PR TITLE
Fix crash on cancel

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -358,6 +358,12 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
                                 success:(void (^)(AFOAuth1Token *accessToken, id responseObject))success
                                 failure:(void (^)(NSError *error))failure
 {
+    if (!requestToken.key || !requestToken.verifier) {
+        // request was cancelled
+        success(nil, nil);
+        return;
+    }
+
     self.accessToken = requestToken;
 
     NSMutableDictionary *parameters = [[self OAuthParameters] mutableCopy];


### PR DESCRIPTION
Tapping cancel from the twitter login screen caused a crash (specifically: it attempted to insert the nil verifier into a dictionary)

Calling the success block sidesteps the crash and doesn't cause the client app to behave as if the operation failed (since it was cancelled deliberately we presume)
