### PR TITLE
Fix a bug where the wrong path was being signed

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -403,7 +403,7 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
         authorizationParameters = ([[request valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"application/x-www-form-urlencoded"] ? parameters : nil);
     }
     
-    [request setValue:[self authorizationHeaderForMethod:method path:path parameters:authorizationParameters] forHTTPHeaderField:@"Authorization"];
+    [request setValue:[self authorizationHeaderForMethod:method path:[[request URL] path] parameters:authorizationParameters] forHTTPHeaderField:@"Authorization"];
     [request setHTTPShouldHandleCookies:NO];
     
     return request;
@@ -419,7 +419,7 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
     // Only use parameters in the HTTP POST request body (with a content-type of `application/x-www-form-urlencoded`).
     // See RFC 5849, Section 3.4.1.3.1 http://tools.ietf.org/html/rfc5849#section-3.4
     NSDictionary *authorizationParameters = ([[request valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"application/x-www-form-urlencoded"] ? parameters : nil);
-    [request setValue:[self authorizationHeaderForMethod:method path:path parameters:authorizationParameters] forHTTPHeaderField:@"Authorization"];
+    [request setValue:[self authorizationHeaderForMethod:method path:[[request URL] path] parameters:authorizationParameters] forHTTPHeaderField:@"Authorization"];
     [request setHTTPShouldHandleCookies:NO];
     
     return request;


### PR DESCRIPTION
If you have set a baseURL which is something like: http://api.something.com/1/
When you do the following:

``` objective-c
[self requestWithMethod:@"GET" path:@"user" parameters:nil];
```

The URL should be:

```
http://api.something.com/1/user
```

Thus, the path should be:

```
/1/user
```

However, it is passing the suffix of the path to the oauth signing code so it
is instead signing:

```
user
```
