### PR TITLE
Fix the incorrect checking for not GET, HEAD and DELETE.

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -404,7 +404,7 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
     // Only use parameters in the request entity body (with a content-type of `application/x-www-form-urlencoded`).
     // See RFC 5849, Section 3.4.1.3.1 http://tools.ietf.org/html/rfc5849#section-3.4
     NSDictionary *authorizationParameters = parameters;
-    if (![method isEqualToString:@"GET"] || ![method isEqualToString:@"HEAD"] || ![method isEqualToString:@"DELETE"]) {
+    if (![method isEqualToString:@"GET"] && ![method isEqualToString:@"HEAD"] && ![method isEqualToString:@"DELETE"]) {
         authorizationParameters = ([[request valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"application/x-www-form-urlencoded"] ? parameters : nil);
     }
     


### PR DESCRIPTION
The GET requests fail with 'incorrect oauth signature' error.  This patch fixes the problem.
