### PR TITLE
Temporary fix for handling a user denying access for oauth

### DIFF
--- a/AFOAuth1Client.podspec
+++ b/AFOAuth1Client.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "AFOAuth1Client"
-  s.version      = "0.3.2"
+  s.version      = "0.3.21"
   s.summary      = "AFNetworking Extension for OAuth 1.0a Authentication."
   s.homepage     = "https://github.com/AFNetworking/AFOAuth1Client"
   s.license      = 'MIT'
   s.author       = { 'Mattt Thompson' => 'm@mattt.me' }
-  s.source       = { :git => "https://github.com/AFNetworking/AFOAuth1Client.git", :tag => '0.3.2' }
+  s.source       = { :git => "git@github.com:mikekey/AFOAuth1Client.git", :tag => '0.3.21' }
   s.source_files = 'AFOAuth1Client'
   s.requires_arc = true
 
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.7'
   s.osx.frameworks = 'CoreServices', 'SystemConfiguration', 'Security'
 
-  s.dependency 'AFNetworking', '~> 1.3'
+  s.dependency 'AFNetworking', '~> 1.3.0'
 
   s.prefix_header_contents = <<-EOS
 #import <Availability.h>

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -285,6 +285,10 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
 
             currentRequestToken.verifier = [AFParametersFromQueryString([url query]) valueForKey:@"oauth_verifier"];
 
+            if (currentRequestToken.verifier == nil) {
+                failure([NSError errorWithDomain:@"Oauth Authorization" code:401 userInfo:@{@"Access Denied":@"User denied access"}]);
+                return;
+            }
             [self acquireOAuthAccessTokenWithPath:accessTokenPath requestToken:currentRequestToken accessMethod:accessMethod success:^(AFOAuth1Token * accessToken, id responseObject) {
                 self.applicationLaunchNotificationObserver = nil;
                 if (accessToken) {


### PR DESCRIPTION
I'm not sure if this is a good fix for the whole of the library nor if its even needed. The spec doesn't say much about how to deal with this issue other than the fact that on a deny there will be no verifier. I patched this to handle a crash that was occurring when a user denied access during testing. Hopefully its useful.
