### PR TITLE
Fix for OAuth providers that don't use oauth_verifier

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -679,7 +679,7 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
     self.session = [decoder decodeObjectForKey:NSStringFromSelector(@selector(session))];
     self.verifier = [decoder decodeObjectForKey:NSStringFromSelector(@selector(verifier))];
     self.expiration = [decoder decodeObjectForKey:NSStringFromSelector(@selector(expiration))];
-    self.renewable = [decoder decodeBoolForKey:NSStringFromSelector(@selector(renewable))];
+    self.renewable = [decoder decodeBoolForKey:NSStringFromSelector(@selector(canBeRenewed))];
     self.userInfo = [decoder decodeObjectForKey:NSStringFromSelector(@selector(userInfo))];
 
     return self;
@@ -691,7 +691,7 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
     [coder encodeObject:self.session forKey:NSStringFromSelector(@selector(session))];
     [coder encodeObject:self.verifier forKey:NSStringFromSelector(@selector(verifier))];
     [coder encodeObject:self.expiration forKey:NSStringFromSelector(@selector(expiration))];
-    [coder encodeBool:self.renewable forKey:NSStringFromSelector(@selector(renewable))];
+    [coder encodeBool:self.renewable forKey:NSStringFromSelector(@selector(canBeRenewed))];
     [coder encodeObject:self.userInfo forKey:NSStringFromSelector(@selector(userInfo))];
 }
 

--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -383,12 +383,14 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
                                 success:(void (^)(AFOAuth1Token *accessToken, id responseObject))success
                                 failure:(void (^)(NSError *error))failure
 {
-    if (requestToken.key && requestToken.verifier) {
+    if (requestToken.key) {
         self.accessToken = requestToken;
         
         NSMutableDictionary *parameters = [[self OAuthParameters] mutableCopy];
         parameters[@"oauth_token"] = requestToken.key;
-        parameters[@"oauth_verifier"] = requestToken.verifier;
+        if (requestToken.verifier) {
+            parameters[@"oauth_verifier"] = requestToken.verifier;
+        }
         
         NSMutableURLRequest *request = [self requestWithMethod:accessMethod path:path parameters:parameters];
         


### PR DESCRIPTION
Bumped into this issue when authenticating to TripIt's API. You could argue that this doesn't follow the spec, but it's such a simple fix.
