### PR TITLE
oAuth 1.0a oauth_callback parameter not necessarily a URL or present

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -355,7 +355,8 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
                                  failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *parameters = [[self OAuthParameters] mutableCopy];
-    parameters[@"oauth_callback"] = [callbackURL absoluteString];
+	if ( callbackURL != nil )
+		parameters[@"oauth_callback"] = [callbackURL absoluteString];
     if (scope && !self.accessToken) {
         parameters[@"scope"] = scope;
     }


### PR DESCRIPTION
6.1.1.  Consumer Obtains a Request Token
An absolute URL to which the Service Provider will redirect the User back when the Obtaining User Authorization step is completed. If the Consumer is unable to receive callbacks or a callback URL has been established via other means, the parameter value MUST be set to oob (case sensitive), to indicate an out-of-band configuration.
