### PR TITLE
Fix issue with empty string passed as Scope

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.m
+++ b/AFOAuth1Client/AFOAuth1Client.m
@@ -356,7 +356,7 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
 {
     NSMutableDictionary *parameters = [[self OAuthParameters] mutableCopy];
     parameters[@"oauth_callback"] = [callbackURL absoluteString];
-    if (scope && !self.accessToken) {
+    if (scope && scope.length > 0 && !self.accessToken) {
         parameters[@"scope"] = scope;
     }
 


### PR DESCRIPTION
Some folks ([example](http://stackoverflow.com/questions/17150868/ios-restkit-and-oauth-simple-sample-not-working/26932868#26932868)) try to pass empty string in scope parameter that leads to 401 error.

This commit adds check for the length of the scope.
