### PR TITLE
Use framework referencing for AFHTTPClient

### DIFF
--- a/AFOAuth1Client/AFOAuth1Client.h
+++ b/AFOAuth1Client/AFOAuth1Client.h
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFHTTPClient.h"
+#import <AFNetworking/AFHTTPClient.h>
 
 typedef NS_ENUM(NSUInteger, AFOAuthSignatureMethod) {
     AFPlainTextSignatureMethod = 1,


### PR DESCRIPTION
Your call on whether to merge this, but this lib can't be turned into a framework with the direct-style header imports in `AFOAuth1Client.h`.

Should work with all versions of CP.
